### PR TITLE
Add redirect to GitHub repo until website is ready

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-<p style="text-align:center;">
+<p align="center">
 <img src="https://www.davelee.de/common/assets/img/portfolio/mdiscis-logo.png" alt="MDISCIS" width="300" height="300">
 </p>
 
-<p style="text-align:center;"><a href="https://app.codacy.com/manual/dave_33/mdiscis?utm_source=github.com&utm_medium=referral&utm_content=daveajlee/mdiscis&utm_campaign=Badge_Grade_Dashboard"><img src="https://api.codacy.com/project/badge/Grade/08a75b0abb064c78863218778917c385" alt="Codacy Badge"> </a>
+<p align="center"><a href="https://app.codacy.com/manual/dave_33/mdiscis?utm_source=github.com&utm_medium=referral&utm_content=daveajlee/mdiscis&utm_campaign=Badge_Grade_Dashboard"><img src="https://api.codacy.com/project/badge/Grade/08a75b0abb064c78863218778917c385" alt="Codacy Badge"> </a>
 </p>
 
 MDISCIS is an application for indexing Minidiscs. Minidiscs do not allow artists and titles to be saved as track information. As a consequence, I developed MDISCIS in January 2003 as a solution to this problem. It acts as an information system for Minidiscs. The program has since then been regularly updated for new Java versions up to and including Java 11. MDISCIS is an open source project but is no longer in active development.

--- a/docs/index.html
+++ b/docs/index.html
@@ -3,9 +3,15 @@
 <head>
     <link rel="icon" href="favicon.ico" />
     <link rel="apple-touch-icon" href="logo192.png" />
+    <meta http-equiv="refresh" content="0; url=https://github.com/daveajlee/mdiscis">
+    <script type="text/javascript">
+        window.location.href = "https://github.com/daveajlee/mdiscis"
+    </script>
     <title>MDISCIS</title>
 </head>
 <body>
-    <h1>MDISCIS Website Coming Soon...</h1>
+<h1>If you are not redirected automatically, follow this <a href='https://github.com/daveajlee/mdiscis'>link to
+    the temporary MDISCIS website</a>.</h1>
 </body>
 </html>
+


### PR DESCRIPTION
Add a redirect via JavaScript and meta tags to GitHub repository until the real web site is ready.